### PR TITLE
Normalize ruamel types returned by load_yaml_files

### DIFF
--- a/nac_yaml/yaml.py
+++ b/nac_yaml/yaml.py
@@ -6,9 +6,12 @@ import logging
 import os
 import subprocess  # nosec B404
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar, cast
 
 from ruamel import yaml
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+
+T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
@@ -197,8 +200,8 @@ def load_yaml_files(paths: list[Path], deduplicate: bool = True) -> dict[str, An
         with open(file_path) as file:
             if file_path.suffix in [".yaml", ".yml"]:
                 data_yaml = file.read()
-                dict = y.load(data_yaml)
-                merge_dict(dict, data, deduplicate)
+                loaded = y.load(data_yaml)
+                merge_dict(loaded, data, deduplicate)
 
     result: dict[str, Any] = {}
     for path in paths:
@@ -211,7 +214,23 @@ def load_yaml_files(paths: list[Path], deduplicate: bool = True) -> dict[str, An
                         _load_file(Path(dir, filename), result)
                     except:  # noqa: E722
                         logger.warning(f"Could not load file: {filename}")
-    return result
+
+    return _to_builtin_types(result)
+
+
+def _to_builtin_types(value: T) -> T:
+    v: Any = value
+    if isinstance(v, CommentedMap):
+        v = dict(v)
+    elif isinstance(v, CommentedSeq):
+        v = list(v)
+
+    if isinstance(v, dict):
+        v = {k: _to_builtin_types(vv) for k, vv in v.items()}
+    elif isinstance(v, list):
+        v = [_to_builtin_types(vv) for vv in v]
+
+    return cast(T, v)
 
 
 def _items_would_merge(item1: dict[str, Any], item2: dict[str, Any]) -> bool:

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2026
+
+from pathlib import Path
+
+import pytest
+
+from nac_yaml.yaml import load_yaml_files
+
+pytestmark = pytest.mark.unit
+
+
+def test_load_yaml_files_returns_plain_types_compatible_with_get(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.yaml"
+    input_path.write_text(
+        """---
+root:
+  feature_profiles:
+    - - name: profile1
+"""
+    )
+
+    data = load_yaml_files([input_path])
+
+    # This used to fail when ruamel types leaked out (inner list item is a list/CommentedSeq)
+    # and downstream code did `p.get(...)`.
+    feature_profiles = data["root"]["feature_profiles"]
+    assert isinstance(feature_profiles, list)
+    assert isinstance(feature_profiles[0], list)
+    assert isinstance(feature_profiles[0][0], dict)
+
+    # Simulate downstream code doing `.get()` on each element.
+    found = next((p for p in feature_profiles[0] if p.get("name") == "profile1"), None)
+    assert found == {"name": "profile1"}


### PR DESCRIPTION
## Summary
- Deep-convert ruamel CommentedMap/CommentedSeq to plain dict/list before returning from load_yaml_files.
- Add regression test covering downstream `.get()` failure mode.

Fixes #47.

## Test plan
- [x] uv run mypy nac_yaml
- [x] uv run pytest -q

Tested the fix with the failing nac-sdwan data:

1. Failing:

```
(.venv) OBOEHMER-M-5D76:nac-sdwan oboehmer$ nac-validate --schema schemas/schema.yaml --rules validation/rules/ tests/integration/fixtures/sdwan/standard_2015/
ERROR - Unexpected error: 'CommentedSeq' object has no attribute 'get'
(.venv) OBOEHMER-M-5D76:nac-sdwan oboehmer$
```

2. with the fix:
```
(.venv) OBOEHMER-M-5D76:nac-sdwan oboehmer$ nac-validate --schema schemas/schema.yaml --rules validation/rules/ tests/integration/fixtures/sdwan/standard_2015/
(.venv) OBOEHMER-M-5D76:nac-sdwan oboehmer$ echo $?
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)